### PR TITLE
Support for image_name

### DIFF
--- a/builtin/providers/openstack/provider_test.go
+++ b/builtin/providers/openstack/provider_test.go
@@ -45,9 +45,11 @@ func testAccPreCheck(t *testing.T) {
 	}
 	OS_REGION_NAME = v
 
-	v = os.Getenv("OS_IMAGE_ID")
-	if v == "" {
-		t.Fatal("OS_IMAGE_ID must be set for acceptance tests")
+	v1 := os.Getenv("OS_IMAGE_ID")
+	v2 := os.Getenv("OS_IMAGE_NAME")
+
+	if v1 == "" && v2 == "" {
+		t.Fatal("OS_IMAGE_ID or OS_IMAGE_NAME must be set for acceptance tests")
 	}
 
 	v = os.Getenv("OS_POOL_NAME")

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -674,10 +674,14 @@ func getFloatingIPs(networkingClient *gophercloud.ServiceClient) ([]floatingips.
 
 func getImageID(client *gophercloud.ServiceClient, d *schema.ResourceData) (string, error) {
 	imageId := d.Get("image_id").(string)
-	imageName := d.Get("image_name").(string)
-	imageCount := 0
 
-	if imageId == "" && imageName != "" {
+	if imageId != "" {
+		return imageId, nil
+	}
+
+	imageCount := 0
+	imageName := d.Get("image_name").(string)
+	if imageName != "" {
 		pager := images.ListDetail(client, &images.ListOpts{
 			Name: imageName,
 		})
@@ -705,11 +709,5 @@ func getImageID(client *gophercloud.ServiceClient, d *schema.ResourceData) (stri
 			return "", fmt.Errorf("Found %d images matching %s", imageCount, imageName)
 		}
 	}
-
-	if imageId == "" && imageName == "" {
-		return "", fmt.Errorf("Neither an image ID nor an image name were able to be determined.")
-	}
-
-	return imageId, nil
-
+	return "", fmt.Errorf("Neither an image ID nor an image name were able to be determined.")
 }

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -15,7 +15,7 @@ Manages a V2 VM instance resource within OpenStack.
 ```
 resource "openstack_compute_instance_v2" "test-server" {
   name = "tf-test"
-  image_ref = "ad091b52-742f-469e-8f3c-fd81cadf0743"
+  image_id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
   flavor_ref = "3"
   metadata {
     this = "that"
@@ -35,8 +35,13 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource.
 
-* `image_ref` - (Required) The image reference (ID) for the desired image for
-    the server. Changing this creates a new server.
+* `image_id` - (Required) The image reference (ID) for the desired image for
+    the server. Changing this creates a new server. Note that `image_id` and
+    `image_name` are mutually exclusive.
+
+* `image_name` - (Required) The image name for the server. Changing this
+   creates a new server. Note that `image_id` and `image_name` are mutually
+   exclusive.
 
 * `flavor_ref` - (Required) The flavor reference (ID) for the desired flavor
     for the server. Changing this resizes the existing server.

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -35,13 +35,11 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource.
 
-* `image_id` - (Required) The image ID of the desired image for the server.
-    Changing this creates a new server. Note that `image_id` and `image_name`
-    are mutually exclusive.
+* `image_id` - (Optional; Required if `image_name` is empty) The image ID of
+    the desired image for the server. Changing this creates a new server.
 
-* `image_name` - (Required) The image name for the server. Changing this
-   creates a new server. Note that `image_id` and `image_name` are mutually
-   exclusive.
+* `image_name` - (Optional; Required if `image_id` is empty) The name of the
+    desired image for the server. Changing this creates a new server.
 
 * `flavor_ref` - (Required) The flavor reference (ID) for the desired flavor
     for the server. Changing this resizes the existing server.

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -35,9 +35,9 @@ The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource.
 
-* `image_id` - (Required) The image reference (ID) for the desired image for
-    the server. Changing this creates a new server. Note that `image_id` and
-    `image_name` are mutually exclusive.
+* `image_id` - (Required) The image ID of the desired image for the server.
+    Changing this creates a new server. Note that `image_id` and `image_name`
+    are mutually exclusive.
 
 * `image_name` - (Required) The image name for the server. Changing this
    creates a new server. Note that `image_id` and `image_name` are mutually


### PR DESCRIPTION
This commit renames image_ref to image_id and adds the image_name
parameter. Users can now specify either an image UUID or image name
when launching instances.

image_name is preferrable as deployers/sysadmins generally regularly
deprecate/remove outdated and insecure images. Using a consistent
naming scheme allows end-users to always retrieve a working image.
