### PR TITLE
Support for flavor_name

### DIFF
--- a/builtin/providers/openstack/provider_test.go
+++ b/builtin/providers/openstack/provider_test.go
@@ -58,8 +58,9 @@ func testAccPreCheck(t *testing.T) {
 	}
 	OS_POOL_NAME = v
 
-	v = os.Getenv("OS_FLAVOR_ID")
-	if v == "" {
-		t.Fatal("OS_FLAVOR_ID must be set for acceptance tests")
+	v1 = os.Getenv("OS_FLAVOR_ID")
+	v2 = os.Getenv("OS_FLAVOR_NAME")
+	if v1 == "" && v2 == "" {
+		t.Fatal("OS_FLAVOR_ID or OS_FLAVOR_NAME must be set for acceptance tests")
 	}
 }

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -767,5 +767,5 @@ func getFlavorID(client *gophercloud.ServiceClient, d *schema.ResourceData) (str
 			return "", fmt.Errorf("Found %d flavors matching %s", flavorCount, flavorName)
 		}
 	}
-	return "", fmt.Errorf("Neither an flavor ID nor an flavor name were able to be determined.")
+	return "", fmt.Errorf("Neither a flavor ID nor a flavor name were able to be determined.")
 }

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -16,7 +16,7 @@ Manages a V2 VM instance resource within OpenStack.
 resource "openstack_compute_instance_v2" "test-server" {
   name = "tf-test"
   image_id = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_ref = "3"
+  flavor_id = "3"
   metadata {
     this = "that"
   }
@@ -41,8 +41,11 @@ The following arguments are supported:
 * `image_name` - (Optional; Required if `image_id` is empty) The name of the
     desired image for the server. Changing this creates a new server.
 
-* `flavor_ref` - (Required) The flavor reference (ID) for the desired flavor
-    for the server. Changing this resizes the existing server.
+* `flavor_id` - (Optional; Required if `flavor_name` is empty) The flavor ID of
+    the desired flavor for the server. Changing this resizes the existing server.
+
+* `flavor_name` - (Optional; Required if `flavor_id` is empty) The name of the
+    desired flavor for the server. Changing this resizes the existing server.
 
 * `security_groups` - (Optional) An array of one or more security group names
     to associate with the server. Changing this results in adding/removing


### PR DESCRIPTION
This commit renames flavor_ref to flavor_id and adds the flavor_name
parameter. Users can now specify either a flavor ID or name when launching
instances.
