### PR TITLE
This commit enables both the image_id and the image_name to be

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -44,12 +44,14 @@ func resourceComputeInstanceV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
+				Computed:    true,
 				DefaultFunc: envDefaultFunc("OS_IMAGE_ID"),
 			},
 			"image_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
+				Computed:    true,
 				DefaultFunc: envDefaultFunc("OS_IMAGE_NAME"),
 			},
 			"flavor_ref": &schema.Schema{
@@ -332,6 +334,18 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error setting OpenStack server's flavor: %v", server.Flavor)
 	}
 	d.Set("flavor_ref", newFlavor)
+
+	imageId, ok := server.Image["id"].(string)
+	if !ok {
+		return fmt.Errorf("Error setting OpenStack server's image: %v", server.Image)
+	}
+	d.Set("image_id", imageId)
+
+	image, err := images.Get(computeClient, imageId).Extract()
+	if err != nil {
+		return err
+	}
+	d.Set("image_name", image.Name)
 
 	return nil
 }


### PR DESCRIPTION
computed, so that specifying one will populate the other.
