### PR TITLE
openstack_compute_floatingip_v2

### DIFF
--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -63,6 +63,7 @@ func Provider() terraform.ResourceProvider {
 			"openstack_compute_instance_v2":            resourceComputeInstanceV2(),
 			"openstack_compute_keypair_v2":             resourceComputeKeypairV2(),
 			"openstack_compute_secgroup_v2":            resourceComputeSecGroupV2(),
+			"openstack_compute_floatingip_v2":          resourceComputeFloatingIPV2(),
 			"openstack_lb_monitor_v1":                  resourceLBMonitorV1(),
 			"openstack_lb_pool_v1":                     resourceLBPoolV1(),
 			"openstack_lb_vip_v1":                      resourceLBVipV1(),

--- a/builtin/providers/openstack/resource_openstack_compute_floatingip_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_floatingip_v2.go
@@ -83,7 +83,7 @@ func resourceComputeFloatingIPV2Read(d *schema.ResourceData, meta interface{}) e
 
 	fip, err := floatingip.Get(computeClient, d.Id()).Extract()
 	if err != nil {
-		return fmt.Errorf("Error getting Floating IP: %s", err)
+		return CheckDeleted(d, err, "floating ip")
 	}
 
 	log.Printf("[DEBUG] Retrieved Floating IP %s: %+v", d.Id(), fip)
@@ -105,15 +105,8 @@ func resourceComputeFloatingIPV2Delete(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
 
-	fip, err := floatingip.Get(computeClient, d.Id()).Extract()
-	if err != nil {
-		return fmt.Errorf("Error getting Floating IP for update: %s", err)
-	}
-
-	log.Printf("[DEBUG] Deleting Floating IP %s", fip.IP)
-
-	// Now do the actual deletion
-	if err := floatingip.Delete(computeClient, fip.ID).ExtractErr(); err != nil {
+	log.Printf("[DEBUG] Deleting Floating IP %s", d.Id())
+	if err := floatingip.Delete(computeClient, d.Id()).ExtractErr(); err != nil {
 		return fmt.Errorf("Error deleting Floating IP: %s", err)
 	}
 

--- a/builtin/providers/openstack/resource_openstack_compute_floatingip_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_floatingip_v2.go
@@ -1,0 +1,121 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/floatingip"
+)
+
+func resourceComputeFloatingIPV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceComputeFloatingIPV2Create,
+		Read:   resourceComputeFloatingIPV2Read,
+		Update: nil,
+		Delete: resourceComputeFloatingIPV2Delete,
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				DefaultFunc: envDefaultFunc("OS_REGION_NAME"),
+			},
+
+			"pool": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				DefaultFunc: envDefaultFunc("OS_POOL_NAME"),
+			},
+
+			// exported
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"address": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"fixed_ip": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"instance_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceComputeFloatingIPV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	createOpts := &floatingip.CreateOpts{
+		Pool: d.Get("pool").(string),
+	}
+	newFip, err := floatingip.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating Floating IP: %s", err)
+	}
+
+	d.SetId(newFip.ID)
+
+	return resourceComputeFloatingIPV2Read(d, meta)
+}
+
+func resourceComputeFloatingIPV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	fip, err := floatingip.Get(computeClient, d.Id()).Extract()
+	if err != nil {
+		return fmt.Errorf("Error getting Floating IP: %s", err)
+	}
+
+	log.Printf("[DEBUG] Retrieved Floating IP %s: %+v", d.Id(), fip)
+
+	d.Set("id", d.Id())
+	d.Set("region", d.Get("region").(string))
+	d.Set("pool", fip.Pool)
+	d.Set("instance_id", fip.InstanceID)
+	d.Set("address", fip.IP)
+	d.Set("fixed_ip", fip.FixedIP)
+
+	return nil
+}
+
+func resourceComputeFloatingIPV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	computeClient, err := config.computeV2Client(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
+	}
+
+	fip, err := floatingip.Get(computeClient, d.Id()).Extract()
+	if err != nil {
+		return fmt.Errorf("Error getting Floating IP for update: %s", err)
+	}
+
+	log.Printf("[DEBUG] Deleting Floating IP %s", fip.IP)
+
+	// Now do the actual deletion
+	if err := floatingip.Delete(computeClient, fip.ID).ExtractErr(); err != nil {
+		return fmt.Errorf("Error deleting Floating IP: %s", err)
+	}
+
+	return nil
+}

--- a/builtin/providers/openstack/resource_openstack_compute_floatingip_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_floatingip_v2_test.go
@@ -1,0 +1,86 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/floatingip"
+)
+
+func TestAccComputeV2FloatingIP_basic(t *testing.T) {
+	var floatingIP floatingip.FloatingIP
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2FloatingIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2FloatingIP_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2FloatingIPExists(t, "openstack_compute_floatingip_v2.foo", &floatingIP),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeV2FloatingIPDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	computeClient, err := config.computeV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("(testAccCheckComputeV2FloatingIPDestroy) Error creating OpenStack compute client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "openstack_compute_floatingip_v2" {
+			continue
+		}
+
+		_, err := floatingip.Get(computeClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("FloatingIP still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckComputeV2FloatingIPExists(t *testing.T, n string, kp *floatingip.FloatingIP) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		computeClient, err := config.computeV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("(testAccCheckComputeV2FloatingIPExists) Error creating OpenStack compute client: %s", err)
+		}
+
+		found, err := floatingip.Get(computeClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("FloatingIP not found")
+		}
+
+		*kp = *found
+
+		return nil
+	}
+}
+
+var testAccComputeV2FloatingIP_basic = fmt.Sprintf(`
+  resource "openstack_compute_floatingip_v2" "foo" {
+  }`)


### PR DESCRIPTION
This commit adds a resource that allows the user to allocate,
deallocate, associate, and disassociate floating IPs through the
nova api.
