### PR TITLE
Replace perigee.UnexpectedResponseCodeError with gophercloud.UnexpectedResponseCodeError

### DIFF
--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack/blockstorage/v1/volumes"
 )
@@ -252,7 +251,7 @@ func VolumeV1StateRefreshFunc(client *gophercloud.ServiceClient, volumeID string
 	return func() (interface{}, string, error) {
 		v, err := volumes.Get(client, volumeID).Extract()
 		if err != nil {
-			errCode, ok := err.(*perigee.UnexpectedResponseCodeError)
+			errCode, ok := err.(*gophercloud.UnexpectedResponseCodeError)
 			if !ok {
 				return nil, "", err
 			}

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/racker/perigee"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/keypairs"
@@ -513,7 +512,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 		for _, g := range secgroupsToRemove.List() {
 			err := secgroups.RemoveServerFromGroup(computeClient, d.Id(), g.(string)).ExtractErr()
 			if err != nil {
-				errCode, ok := err.(*perigee.UnexpectedResponseCodeError)
+				errCode, ok := err.(*gophercloud.UnexpectedResponseCodeError)
 				if !ok {
 					return fmt.Errorf("Error removing security group from OpenStack server (%s): %s", d.Id(), err)
 				}
@@ -683,7 +682,7 @@ func ServerV2StateRefreshFunc(client *gophercloud.ServiceClient, instanceID stri
 	return func() (interface{}, string, error) {
 		s, err := servers.Get(client, instanceID).Extract()
 		if err != nil {
-			errCode, ok := err.(*perigee.UnexpectedResponseCodeError)
+			errCode, ok := err.(*gophercloud.UnexpectedResponseCodeError)
 			if !ok {
 				return nil, "", err
 			}

--- a/builtin/providers/openstack/resource_openstack_compute_secgroup_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_secgroup_v2.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/racker/perigee"
+	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/extensions/secgroups"
 )
 
@@ -171,7 +171,7 @@ func resourceComputeSecGroupV2Update(d *schema.ResourceData, meta interface{}) e
 			rule := resourceSecGroupRuleV2(d, r)
 			err := secgroups.DeleteRule(computeClient, rule.ID).ExtractErr()
 			if err != nil {
-				errCode, ok := err.(*perigee.UnexpectedResponseCodeError)
+				errCode, ok := err.(*gophercloud.UnexpectedResponseCodeError)
 				if !ok {
 					return fmt.Errorf("Error removing rule (%s) from OpenStack security group (%s): %s", rule.ID, d.Id(), err)
 				}

--- a/builtin/providers/openstack/resource_openstack_networking_router_interface_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_interface_v2.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/racker/perigee"
+	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/rackspace/gophercloud/openstack/networking/v2/ports"
 )
@@ -69,7 +69,7 @@ func resourceNetworkingRouterInterfaceV2Read(d *schema.ResourceData, meta interf
 
 	n, err := ports.Get(networkingClient, d.Id()).Extract()
 	if err != nil {
-		httpError, ok := err.(*perigee.UnexpectedResponseCodeError)
+		httpError, ok := err.(*gophercloud.UnexpectedResponseCodeError)
 		if !ok {
 			return fmt.Errorf("Error retrieving OpenStack Neutron Router Interface: %s", err)
 		}

--- a/builtin/providers/openstack/resource_openstack_networking_router_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_router_v2.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/racker/perigee"
+	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 )
 
@@ -98,7 +98,7 @@ func resourceNetworkingRouterV2Read(d *schema.ResourceData, meta interface{}) er
 
 	n, err := routers.Get(networkingClient, d.Id()).Extract()
 	if err != nil {
-		httpError, ok := err.(*perigee.UnexpectedResponseCodeError)
+		httpError, ok := err.(*gophercloud.UnexpectedResponseCodeError)
 		if !ok {
 			return fmt.Errorf("Error retrieving OpenStack Neutron Router: %s", err)
 		}

--- a/builtin/providers/openstack/util.go
+++ b/builtin/providers/openstack/util.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/racker/perigee"
+	"github.com/rackspace/gophercloud"
 )
 
 // CheckDeleted checks the error to see if it's a 404 (Not Found) and, if so,
 // sets the resource ID to the empty string instead of throwing an error.
 func CheckDeleted(d *schema.ResourceData, err error, msg string) error {
-	errCode, ok := err.(*perigee.UnexpectedResponseCodeError)
+	errCode, ok := err.(*gophercloud.UnexpectedResponseCodeError)
 	if !ok {
 		return fmt.Errorf("%s: %s", msg, err)
 	}


### PR DESCRIPTION
Since the creation of the Request method (https://github.com/rackspace/gophercloud/commit/89eec330122140f0e042570130ed54911015e025 and following _rackspace :knife: perigee_ commits), Gophercloud returns gophercloud.UnexpectedResponseCodeError instead of perigee.UnexpectedResponseCodeError.
